### PR TITLE
Correctly resolve older dependencies

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -29,20 +29,21 @@ class WitnessPlugin implements Plugin<Project> {
                     List  parts  = assertion.tokenize(":")
                     String group = parts.get(0)
                     String name  = parts.get(1)
-                    String hash  = parts.get(2)
+                    String version  = parts.get(2)
+                    String hash  = parts.get(3)
 
                     ResolvedArtifact dependency = project.configurations.compile.resolvedConfiguration.resolvedArtifacts.find {
-                        return it.name.equals(name) && it.moduleVersion.id.group.equals(group)
+                        return it.name.equals(name) && it.moduleVersion.id.group.equals(group) && it.moduleVersion.id.version.equals(version)
                     }
 
-                    println "Verifying " + group + ":" + name
+                    println "Verifying " + dependency.moduleVersion.id.group + ":" + dependency.name + ":" + dependency.moduleVersion.id.version
 
                     if (dependency == null) {
-                        throw new InvalidUserDataException("No dependency for integrity assertion found: " + group + ":" + name)
+                        throw new InvalidUserDataException("No dependency for integrity assertion found: " + group + ":" + name + ":" + dependency.moduleVersion.id.version)
                     }
 
                     if (!hash.equals(calculateSha256(dependency.file))) {
-                        throw new InvalidUserDataException("Checksum failed for " + assertion)
+                        throw new InvalidUserDataException("Checksum failed for " + assertion + "\n" +"actual SHA256 = "+calculatedHash)
                     }
             }
         }
@@ -53,7 +54,7 @@ class WitnessPlugin implements Plugin<Project> {
 
             project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
                 dep ->
-                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
+                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + dep.moduleVersion.id.version + ":" + calculateSha256(dep.file) + "',"
             }
 
             println "    ]"


### PR DESCRIPTION
fixes a bug where Witness would always resolve the most recent version of a dependency even if the project specified an older version.